### PR TITLE
Updated hashFunction with flag for trimAll

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -137,9 +137,13 @@ function isAlreadyHashed(input){
 }
 
 
-function hashFunction(input){
+function hashFunction(input, trimAll){
   if(input == null || isAlreadyHashed(input)){
     return input;
+  }
+  
+  if(trimAll){
+    return sha256Sync(input.replaceAll(' ', '').toLowerCase(), {outputEncoding: 'hex'});
   }
 
   return sha256Sync(input.trim().toLowerCase(), {outputEncoding: 'hex'});
@@ -182,17 +186,17 @@ event.user_data.client_user_agent = eventModel.user_agent;
 
 // Commmon Event Schema Parameters
 event.user_data.em = eventModel['x-fb-ud-em'] ||
-                        (eventModel.user_data != null ? hashFunction(eventModel.user_data.email_address) : null);
+                        (eventModel.user_data != null ? hashFunction(eventModel.user_data.email_address, true) : null);
 event.user_data.ph = eventModel['x-fb-ud-ph'] ||
-                        (eventModel.user_data != null ? hashFunction(eventModel.user_data.phone_number) : null);
+                        (eventModel.user_data != null ? hashFunction(eventModel.user_data.phone_number, true) : null);
 
 const addressData = (eventModel.user_data != null && eventModel.user_data.address != null) ? eventModel.user_data.address : {};
-event.user_data.fn = eventModel['x-fb-ud-fn'] || hashFunction(addressData.first_name);
-event.user_data.ln = eventModel['x-fb-ud-ln'] || hashFunction(addressData.last_name);
-event.user_data.ct = eventModel['x-fb-ud-ct'] || hashFunction(addressData.city);
-event.user_data.st = eventModel['x-fb-ud-st'] || hashFunction(addressData.region);
-event.user_data.zp = eventModel['x-fb-ud-zp'] || hashFunction(addressData.postal_code);
-event.user_data.country = eventModel['x-fb-ud-country'] || hashFunction(addressData.country);
+event.user_data.fn = eventModel['x-fb-ud-fn'] || hashFunction(addressData.first_name, false);
+event.user_data.ln = eventModel['x-fb-ud-ln'] || hashFunction(addressData.last_name, false);
+event.user_data.ct = eventModel['x-fb-ud-ct'] || hashFunction(addressData.city, true);
+event.user_data.st = eventModel['x-fb-ud-st'] || hashFunction(addressData.region, true);
+event.user_data.zp = eventModel['x-fb-ud-zp'] || hashFunction(addressData.postal_code, true);
+event.user_data.country = eventModel['x-fb-ud-country'] || hashFunction(addressData.country, true);
 
 // Facebook Specific Parameters
 event.user_data.ge = eventModel['x-fb-ud-ge'];


### PR DESCRIPTION
Since first name and last name are the only one keys that allow spaces we should replace all blank spaces with empty string.

Added boolean flag in hashfunction to use between trim and ”trimAll”.