### PR TITLE
Fix/signup event name

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -129,7 +129,7 @@ const GTM_EVENT_MAPPINGS = {
   "begin_checkout": "InitiateCheckout",
   "generate_lead": "Lead",
   "view_item": "ViewContent",
-  "signup": "CompleteRegistration"
+  "sign_up": "CompleteRegistration"
 };
 
 function isAlreadyHashed(input){


### PR DESCRIPTION
Update the `signup` event name in `GTM_EVENT_MAPPINGS` to match the actual name of the GA4 event, which is `sign_up`. 

This is to fix https://github.com/facebookincubator/ConversionsAPI-Tag-for-GoogleTagManager/issues/10