### PR TITLE
Change API Version to v11.0

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -117,7 +117,7 @@ const getCookieValues = require('getCookieValues');
 
 // Constants
 const API_ENDPOINT = 'https://graph.facebook.com';
-const API_VERSION = 'v10.0';
+const API_VERSION = 'v11.0';
 const PARTNER_AGENT = 'gtmss-1.0.0-0.0.3';
 const GTM_EVENT_MAPPINGS = {
   "add_payment_info": "AddPaymentInfo",
@@ -720,7 +720,7 @@ setup: |-
   });
 
   const apiEndpoint = 'https://graph.facebook.com';
-  const apiVersion = 'v10.0';
+  const apiVersion = 'v11.0';
   const partnerAgent = 'gtmss-1.0.0-0.0.3';
 
   const routeParams = 'events?access_token=' + testConfigurationData.apiAccessToken;


### PR DESCRIPTION
Currently, requests made using this tag from the server container return status code 400 with the following message:
![image](https://user-images.githubusercontent.com/3434572/122113256-3b92ec00-cdf8-11eb-8f75-b331d8e2e4c2.png)

Changing the API Version to 11.0 should fix it. 