### PR TITLE
Allow sending fb_login_id from GA4 Client event model

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -236,6 +236,7 @@ event.user_data.country = eventModel['x-fb-ud-country'] || hashFunction(addressD
 event.user_data.ge = eventModel['x-fb-ud-ge'];
 event.user_data.db = eventModel['x-fb-ud-db'];
 event.user_data.external_id = eventModel['x-fb-ud-external_id'];
+event.user_data.fb_login_id = eventModel['x-fb-ud-fb_login_id'];
 event.user_data.subscription_id = eventModel['x-fb-ud-subscription_id'];
 event.user_data.fbp = eventModel['x-fb-ck-fbp'] || getCookieValues('_fbp', true)[0];
 event.user_data.fbc = getFbcValue();
@@ -290,6 +291,7 @@ sendHttpRequest(
   requestHeaders,
   JSON.stringify(eventRequest)
 );
+
 
 ___SERVER_PERMISSIONS___
 
@@ -500,7 +502,7 @@ ___SERVER_PERMISSIONS___
       "isEditedByUser": true
     },
     "isRequired": true
-  },
+  }
 ]
 
 
@@ -781,8 +783,7 @@ scenarios:
     assertThat(JSON.parse(httpBody).data[0].user_data.st).isEqualTo(hashFunction('ca'));
     assertThat(JSON.parse(httpBody).data[0].user_data.zp).isEqualTo(hashFunction('94025'));
     assertThat(JSON.parse(httpBody).data[0].user_data.country).isEqualTo(hashFunction('usa'));
-
-- name: Set Meta cookies (fbp / fbc) if "extendCookies" checkbox is ticked
+- name: Set Meta cookies (fbp / fbc) if extendCookies checkbox is ticked
   code: |
     runCode({
       pixelId: '123',
@@ -795,8 +796,7 @@ scenarios:
     //Assert
     assertApi('setCookie').wasCalled();
     assertApi('gtmOnSuccess').wasCalled();
-
-- name: Do not set Meta cookies (fbp / fbc) if "extendCookies" checkbox is ticked
+- name: Do not set Meta cookies (fbp / fbc) if extendCookies checkbox is ticked
   code: |
     runCode({
       pixelId: '123',
@@ -848,6 +848,7 @@ setup: |-
       country: 'us',
       zip: '12345',
       external_id: 'user123',
+      fb_login_id: '1234567890987654',
       subscription_id: 'abc123',
       fbp: 'test_browser_id',
       fbc: 'test_click_id',
@@ -886,6 +887,7 @@ setup: |-
     'x-fb-ud-zp': testData.user_data.zip,
     'x-fb-ud-country': testData.user_data.country,
     'x-fb-ud-external_id': testData.user_data.external_id,
+    'x-fb-ud-fb_login_id': testData.user_data.fb_login_id,
     'x-fb-ud-subscription_id': testData.user_data.subscription_id,
     'x-fb-ck-fbp': testData.user_data.fbp,
     'x-fb-ck-fbc': testData.user_data.fbc,
@@ -921,6 +923,7 @@ setup: |-
     'ge': testData.user_data.gender,
     'db': testData.user_data.date_of_brith,
     'external_id': testData.user_data.external_id,
+    'fb_login_id': testData.user_data.fb_login_id,
     'subscription_id': testData.user_data.subscription_id,
     'fbp': testData.user_data.fbp,
     'fbc': testData.user_data.fbc,


### PR DESCRIPTION
## Scenario

While trying to improve event match rate for our site referencing [Best Practices for Conversion API](https://www.facebook.com/business/help/308855623839366?id=818859032317965) published by Meta Business Help Centre, we've noticed that `FB Login ID` ([App-Scoped ID](https://developers.facebook.com/docs/messenger-platform/reference/id-matching-api/#aid)) is categorized as customer information parameter with Medium priority

And it is also documented in [Conversion API Developer documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters)

But for now, `fb_login_id` cannot be submitted with GA4 Client event model, so I mimic how `external_id` is proxied through GA4 Client event model in order to submit `fb_login_id`

## Tests

I've also run the updated code / tests with GTM environment to ensure everything is still in place.

<img width="1790" alt="Screen Shot 2022-05-07 at 1 22 07 AM" src="https://user-images.githubusercontent.com/7748552/167185790-2a92e473-2066-4828-8603-cc036f3bc989.png">
